### PR TITLE
fix: intermittent race condition and concurrent map when implement healthcheck v2 library

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -210,7 +210,16 @@ func (h *healthCheck) StartBackgroundCheck(ctx context.Context) {
 // nolint: gomnd
 func (h *healthCheck) runChecks() {
 	wg := &sync.WaitGroup{}
-	for _, d := range h.dependencies {
+
+	//making a new copy of healthDependencies to avoid race condition
+	healthDependencies := make(map[string]healthDependency)
+	h.dependenciesMutex.Lock()
+	for k, v := range h.dependencies {
+		healthDependencies[k] = v
+	}
+	h.dependenciesMutex.Unlock()
+
+	for _, d := range healthDependencies {
 		wg.Add(1)
 		go h.check(wg, d)
 	}


### PR DESCRIPTION
context:
When I try to implement healthcheck v2 library on chat service, and doing go test with -race command. I got an error message:

```
WARNING: DATA RACE
Write at 0x00c000ab7b90 by goroutine 191:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:203 +0x0
  github.com/AccelByte/healthcheck-go-sdk/v2.(*healthCheck).check()
      /opt/go/src/accelbyte.net/justice-chat-service/vendor/github.com/AccelByte/healthcheck-go-sdk/v2/handler.go:227 +0x204
  github.com/AccelByte/healthcheck-go-sdk/v2.(*healthCheck).runChecks.func1()
      /opt/go/src/accelbyte.net/justice-chat-service/vendor/github.com/AccelByte/healthcheck-go-sdk/v2/handler.go:216 +0xa4

Previous read at 0x00c000ab7b90 by goroutine 26:
  runtime.mapiternext()
      /usr/local/go/src/runtime/map.go:867 +0x0
  github.com/AccelByte/healthcheck-go-sdk/v2.(*healthCheck).runChecks()
      /opt/go/src/accelbyte.net/justice-chat-service/vendor/github.com/AccelByte/healthcheck-go-sdk/v2/handler.go:214 +0x109
  github.com/AccelByte/healthcheck-go-sdk/v2.(*healthCheck).StartBackgroundCheck()
      /opt/go/src/accelbyte.net/justice-chat-service/vendor/github.com/AccelByte/healthcheck-go-sdk/v2/handler.go:192 +0x72
  accelbyte.net/justice-chat-service/pkg/health.(*Health).InitHealthService()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/health/health.go:75 +0xa24
  accelbyte.net/justice-chat-service/pkg/server.New()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/server/server.go:162 +0x28ac
  accelbyte.net/justice-chat-service/pkg/server.(*CoreSuite).StartNode()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/server/core-suite.go:633 +0x605b
  accelbyte.net/justice-chat-service/pkg/server.(*CoreSuite).SetupSuite()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/server/core-suite.go:241 +0x90e
  accelbyte.net/justice-chat-service/pkg/server.(*ChatAutoDeleteSuite).SetupSuite()
      <autogenerated>:1 +0x31
  github.com/stretchr/testify/suite.Run()
      /opt/go/src/accelbyte.net/justice-chat-service/vendor/github.com/stretchr/testify/suite/suite.go:154 +0x63e
  accelbyte.net/justice-chat-service/pkg/server.TestChatAutoDeleteSuiteSuite()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/server/server_auto_delete_chat_test.go:25 +0x8b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x44

Goroutine 191 (running) created at:
  github.com/AccelByte/healthcheck-go-sdk/v2.(*healthCheck).runChecks()
      /opt/go/src/accelbyte.net/justice-chat-service/vendor/github.com/AccelByte/healthcheck-go-sdk/v2/handler.go:216 +0xfc
  github.com/AccelByte/healthcheck-go-sdk/v2.(*healthCheck).StartBackgroundCheck()
      /opt/go/src/accelbyte.net/justice-chat-service/vendor/github.com/AccelByte/healthcheck-go-sdk/v2/handler.go:192 +0x72
  accelbyte.net/justice-chat-service/pkg/health.(*Health).InitHealthService()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/health/health.go:75 +0xa24
  accelbyte.net/justice-chat-service/pkg/server.New()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/server/server.go:162 +0x28ac
  accelbyte.net/justice-chat-service/pkg/server.(*CoreSuite).StartNode()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/server/core-suite.go:633 +0x605b
  accelbyte.net/justice-chat-service/pkg/server.(*CoreSuite).SetupSuite()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/server/core-suite.go:241 +0x90e
  accelbyte.net/justice-chat-service/pkg/server.(*ChatAutoDeleteSuite).SetupSuite()
      <autogenerated>:1 +0x31
  github.com/stretchr/testify/suite.Run()
      /opt/go/src/accelbyte.net/justice-chat-service/vendor/github.com/stretchr/testify/suite/suite.go:154 +0x63e
  accelbyte.net/justice-chat-service/pkg/server.TestChatAutoDeleteSuiteSuite()
      /opt/go/src/accelbyte.net/justice-chat-service/pkg/server/server_auto_delete_chat_test.go:25 +0x8b
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1648 +0x44

Goroutine 26 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1648 +0x845
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2054 +0x84
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1595 +0x261
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2052 +0x8ad
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1925 +0xcd7
  main.main()
      _testmain.go:85 +0x2e4
```

I tried to fix it on my local, and this changes solved the issue, the error gone and the test success.
My guess is the error appeared because there is modification to the map in the iteration