### PR TITLE
feat: add alerts level and method to expose service dependency metrics

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,7 @@ of the dependency check result.
 - The `/healthz` response now returns last call time, last known good call time, and last error message of the corresponding dependency health check
 - New `UpdateHealth` method to enable the implementer service to update a dependency health
 - CheckFunc templates improvements
+- Add `AlertLevel` to adjust dependency priority when its alerted
 
 ## Usage
 #### Installing
@@ -29,20 +30,33 @@ Reference: https://github.com/AccelByte/eventstream-go-sdk#v4
 #### Initiating
 ```go
 h := healthcheck.New(&healthcheck.Config{
-ServiceName: "serviceName",
-BasePath: "/servicePath"},
-BackgroundCheckInterval: 60*time.Second,
+  ServiceName: "serviceName",
+  BasePath: "/servicePath",
+  BackgroundCheckInterval: 60*time.Second,
 })
 ```
 
-#### Registering a (soft) dependency (recommended)
+#### Registering a dependency health check
+
+```go
+redisClient := new(redis.Client)
+timeout := 5 * time.Second
+h.AddDependencyHealthCheck(healthcheck.Dependency{
+		Name:       "redis",
+		URL:        "redis:6379",
+		AlertLevel: healthcheck.Important,
+		CheckFunc:  h.RedisHealthCheck(redisClient, timeout),
+})
+```
+
+#### Registering a (soft) dependency (recommended) (DEPRECATED)
 ```go
 redisClient := new(redis.Client)
 timeout := 5 * time.Second
 h.AddHealthCheck("redis", "redis:6379", h.RedisHealthCheck(redisClient, timeout))
 ```
 
-#### Registering a hard dependency
+#### Registering a hard dependency (DEPRECATED)
 ```go
 h.AddHardHealthCheck("other-dependency", "dependency:1234", func() error {
 // do checking
@@ -60,6 +74,16 @@ h.StartBackgroundCheck(ctx)
 serviceContainer := restful.NewContainer()
 ...
 serviceContainer.Add(h.AddWebservice())
+```
+
+#### Expose dependency health prometheus metrics
+
+```go
+registry := prometheus.NewRegistry()
+h.AddMetrics(registry)
+
+// or add metrics to default prometheus registry
+h.AddMetrics(prometheus.DefaultRegisterer)
 ```
 
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/jinzhu/gorm v1.9.16
 	github.com/olivere/elastic v6.2.35+incompatible
 	github.com/parnurzeal/gorequest v0.2.16
+	github.com/prometheus/client_golang v1.16.0
 	github.com/sha1sum/aws_signing_client v0.0.0-20200229211254-f7815c59d5c1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.2

--- a/handler.go
+++ b/handler.go
@@ -23,6 +23,7 @@ import (
 
 	restfulV1 "github.com/emicklei/go-restful"
 	"github.com/emicklei/go-restful/v3"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,12 +34,13 @@ const (
 )
 
 type healthCheck struct {
-	serviceName       string
-	basePath          string
-	dependenciesMutex sync.RWMutex
-	dependencies      map[string]healthDependency
-	bgCheckRunning    bool
-	bgCheckInterval   time.Duration
+	serviceName             string
+	basePath                string
+	dependenciesMutex       sync.RWMutex
+	dependencies            map[string]healthDependency
+	bgCheckRunning          bool
+	bgCheckInterval         time.Duration
+	dependencyFailureMetric *prometheus.GaugeVec
 }
 
 type Config struct {
@@ -51,13 +53,21 @@ type Handler interface {
 	AddWebservice() []*restful.WebService
 	AddWebserviceV1() []*restfulV1.WebService
 
+	// DEPRECATED: Use AddDependencyHealthCheck instead
 	// AddHealthCheck adds a dependency health check. It will be a soft dependency check, hence if the check failed,
 	// it will only return healthy=false on the corresponding dependency and will not affect the overall healthy status.
 	AddHealthCheck(name, url string, check CheckFunc)
 
+	// DEPRECATED: Use AddDependencyHealthCheck instead
 	// AddHardHealthCheck adds a hard dependency health check.
 	// It will return healthy=false on the corresponding dependency and the overall healthy status.
 	AddHardHealthCheck(name, url string, check CheckFunc)
+
+	// AddDependencyHealthCheck adds dependency health check with provided Dependency object
+	AddDependencyHealthCheck(dep Dependency)
+
+	// AddMetrics adds prometheus metrics for dependency health check failures into provided registerer
+	AddMetrics(registerer prometheus.Registerer) error
 
 	// StartBackgroundCheck starts a background health check worker. The health check will be performed at a
 	// certain interval, specified in Config, rather than every health endpoint request.
@@ -90,10 +100,11 @@ func (h *healthCheck) AddHealthCheck(name, url string, check CheckFunc) {
 	defer h.dependenciesMutex.Unlock()
 
 	h.dependencies[name] = healthDependency{
-		Name:      name,
-		URL:       url,
-		checkFunc: check,
-		LastError: nil,
+		Name:       name,
+		URL:        url,
+		checkFunc:  check,
+		LastError:  nil,
+		AlertLevel: string(Utility),
 	}
 }
 
@@ -103,13 +114,58 @@ func (h *healthCheck) AddHardHealthCheck(name, url string, check CheckFunc) {
 	h.dependenciesMutex.Lock()
 	defer h.dependenciesMutex.Unlock()
 
-	h.dependencies[name] = healthDependency{
+	dependency := healthDependency{
 		Name:           name,
 		URL:            url,
 		HardDependency: true,
 		checkFunc:      check,
 		LastError:      nil,
+		AlertLevel:     string(Important),
 	}
+	h.dependencies[name] = dependency
+	h.initDependencyFailureMetric(&dependency)
+}
+
+func (h *healthCheck) AddDependencyHealthCheck(dep Dependency) {
+	h.dependenciesMutex.Lock()
+	defer h.dependenciesMutex.Unlock()
+
+	if dep.AlertLevel == "" {
+		dep.AlertLevel = None
+	}
+
+	dependency := healthDependency{
+		Name:           dep.Name,
+		URL:            dep.URL,
+		HardDependency: false,
+		LastError:      nil,
+		AlertLevel:     string(dep.AlertLevel),
+		checkFunc:      dep.CheckFunc,
+	}
+	h.dependencies[dep.Name] = dependency
+	h.initDependencyFailureMetric(&dependency)
+}
+
+func (h *healthCheck) AddMetrics(registerer prometheus.Registerer) error {
+	dependencyFailure := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ab_service_dependency_failures",
+			Help: "State of service dependency failures, 0 is healthy 1 is unhealthy",
+		},
+		[]string{"dependency_name", "alert_level"},
+	)
+	if err := registerer.Register(dependencyFailure); err != nil {
+		return err
+	}
+	h.dependencyFailureMetric = dependencyFailure
+
+	h.dependenciesMutex.RLock()
+	defer h.dependenciesMutex.RUnlock()
+	for _, d := range h.dependencies {
+		h.initDependencyFailureMetric(&d)
+	}
+
+	return nil
 }
 
 // UpdateHealth updates a dependency health status.
@@ -134,6 +190,8 @@ func (h *healthCheck) UpdateHealth(name string, isHealthy bool, checkError *Chec
 		}
 	}
 	h.dependencies[name] = dependency
+
+	h.setDependencyFailureMetric(&dependency)
 
 	return nil
 }
@@ -247,6 +305,7 @@ func (h *healthCheck) check(wg *sync.WaitGroup, d healthDependency) {
 	h.dependenciesMutex.Lock()
 	defer h.dependenciesMutex.Unlock()
 	h.dependencies[d.Name] = d
+	h.setDependencyFailureMetric(&d)
 }
 
 func (h *healthCheck) getResponse() (int, *response) {
@@ -296,5 +355,21 @@ func (h *healthCheck) handlerV1(_ *restfulV1.Request, resp *restfulV1.Response) 
 
 	if err := resp.WriteHeaderAndJson(responseStatus, healthStatus, restful.MIME_JSON); err != nil {
 		logrus.Error("Error " + err.Error())
+	}
+}
+
+func (h *healthCheck) initDependencyFailureMetric(d *healthDependency) {
+	if h.dependencyFailureMetric != nil {
+		h.dependencyFailureMetric.WithLabelValues(d.Name, d.AlertLevel)
+	}
+}
+
+func (h *healthCheck) setDependencyFailureMetric(d *healthDependency) {
+	if h.dependencyFailureMetric != nil {
+		num := 0.0
+		if !d.Healthy {
+			num = 1
+		}
+		h.dependencyFailureMetric.WithLabelValues(d.Name, d.AlertLevel).Set(num)
 	}
 }

--- a/types.go
+++ b/types.go
@@ -19,14 +19,32 @@ import (
 	"time"
 )
 
+type AlertLevel string
+
+const (
+	Critical  AlertLevel = "critical"
+	Important AlertLevel = "important"
+	Utility   AlertLevel = "utility"
+	None      AlertLevel = "none"
+)
+
+type Dependency struct {
+	Name       string
+	URL        string
+	AlertLevel AlertLevel
+	CheckFunc  CheckFunc
+}
+
 type healthDependency struct {
-	Name              string     `json:"name"`
-	URL               string     `json:"url"`
-	Healthy           bool       `json:"healthy"`
+	Name    string `json:"name"`
+	URL     string `json:"url"`
+	Healthy bool   `json:"healthy"`
+	// Deprecated: this was replaced with AlertLevel.
 	HardDependency    bool       `json:"hardDependency"`
 	LastKnownGoodCall *time.Time `json:"lastKnownGoodCall,omitempty"`
 	LastCall          *time.Time `json:"lastCall,omitempty"`
 	LastError         *lastError `json:"lastError,omitempty"`
+	AlertLevel        string     `json:"alertLevel"`
 	checkFunc         CheckFunc
 }
 


### PR DESCRIPTION
Changes:
- Add new attribute `AlertLevel` to adjust priority of the dependency in relation to its alerts priority
- Add method `AddMetrics` to expose dependency health failure as Prometheus metrics for monitoring and alerting
- Mark func `AddHardHealthCheck` and `AddHealthCheck` deprecated